### PR TITLE
Compile warning removed.

### DIFF
--- a/APNGKit/APNGImageCache.swift
+++ b/APNGKit/APNGImageCache.swift
@@ -50,9 +50,9 @@ public class APNGCache {
         
         cacheObject.name = "com.onevcat.APNGKit.cache"
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "clearMemoryCache",
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(APNGCache.clearMemoryCache),
                                                                    name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "clearMemoryCache",
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(APNGCache.clearMemoryCache),
                                                                    name: UIApplicationDidEnterBackgroundNotification, object: nil)
     }
     

--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -130,7 +130,7 @@ public class APNGImageView: UIView {
         let currentRunLoop = NSRunLoop.currentRunLoop()
         
         if mainRunLoop != currentRunLoop {
-            performSelectorOnMainThread("startAnimating", withObject: nil, waitUntilDone: false)
+            performSelectorOnMainThread(#selector(APNGImageView.startAnimating), withObject: nil, waitUntilDone: false)
             return
         }
         
@@ -153,7 +153,7 @@ public class APNGImageView: UIView {
         let currentRunLoop = NSRunLoop.currentRunLoop()
         
         if mainRunLoop != currentRunLoop {
-            performSelectorOnMainThread("stopAnimating", withObject: nil, waitUntilDone: false)
+            performSelectorOnMainThread(#selector(APNGImageView.stopAnimating), withObject: nil, waitUntilDone: false)
             return
         }
         
@@ -256,7 +256,7 @@ extension CADisplayLink {
     
     static func apng_displayLink(block: (CADisplayLink) -> ()) -> CADisplayLink
     {
-        let displayLink = CADisplayLink(target: self, selector: "apng_blockInvoke:")
+        let displayLink = CADisplayLink(target: self, selector: #selector(CADisplayLink.apng_blockInvoke(_:)))
         
         let block = Block(block)
         displayLink.apng_setUserInfo(block)

--- a/APNGKit/Disassembler.swift
+++ b/APNGKit/Disassembler.swift
@@ -283,7 +283,9 @@ public struct Disassembler {
             if blendOP == UInt8(PNG_BLEND_OP_SOURCE) {
                 memcpy(dp, sp, Int(width) * 4)
             } else { // APNG_BLEND_OP_OVER
-                for var i = 0; i < Int(width); i++, sp = sp.advancedBy(4), dp = dp.advancedBy(4) {
+                for _ in 0 ... Int(width){
+                    sp = sp.advancedBy(4)
+                    dp = dp.advancedBy(4)
                     let srcAlpha = Int(sp.advancedBy(3).memory) // Blend alpha to dst
                     if srcAlpha == 0xff {
                         memcpy(dp, sp, 4)


### PR DESCRIPTION
I have removed the compiler warning below.

~/APNGKit/APNGImageView.swift:133:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:156:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:259:65: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:53:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:55:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/Disassembler.swift:286:49: warning: '++' is deprecated: it will be removed in Swift 3
~/APNGKit/Disassembler.swift:286:17: warning: C-style for statement is deprecated and will be removed in a future version of Swift
~/APNGKit/APNGImageView.swift:133:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:156:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:259:65: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:53:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:55:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/Disassembler.swift:286:49: warning: '++' is deprecated: it will be removed in Swift 3
~/APNGKit/Disassembler.swift:286:17: warning: C-style for statement is deprecated and will be removed in a future version of Swift
~/APNGKit/APNGImageView.swift:133:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:156:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:259:65: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:53:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:55:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/Disassembler.swift:286:49: warning: '++' is deprecated: it will be removed in Swift 3
~/APNGKit/Disassembler.swift:286:17: warning: C-style for statement is deprecated and will be removed in a future version of Swift
~/APNGKit/APNGImageView.swift:133:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:156:41: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageView.swift:259:65: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:53:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/APNGImageCache.swift:55:74: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
~/APNGKit/Disassembler.swift:286:49: warning: '++' is deprecated: it will be removed in Swift 3
~/APNGKit/Disassembler.swift:286:17: warning: C-style for statement is deprecated and will be removed in a future version of Swift