### PR TITLE
Fix updateCGImageRef bug

### DIFF
--- a/APNGKit/Frame.swift
+++ b/APNGKit/Frame.swift
@@ -78,7 +78,7 @@ struct Frame {
         }
         
         if let imageRef = CGImage(width: width, height: height, bitsPerComponent: bits, bitsPerPixel: bits * 4, bytesPerRow: bytesInRow, space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: [CGBitmapInfo.byteOrder32Big, CGBitmapInfo(rawValue: blend ? CGImageAlphaInfo.last.rawValue : CGImageAlphaInfo.premultipliedLast.rawValue)],
+            bitmapInfo: [CGBitmapInfo.byteOrder32Big, CGBitmapInfo(rawValue: blend ? CGImageAlphaInfo.premultipliedLast.rawValue : CGImageAlphaInfo.last.rawValue)],
                         provider: provider, decode: nil, shouldInterpolate: false, intent: .defaultIntent)
         {
             image = UIImage(cgImage: imageRef, scale: scale, orientation: .up)


### PR DESCRIPTION
updateCGImageRef方法有问题，blend为YES的情况下应当使用CGImageAlphaInfo.premultipliedLast.rawValue。
具体表现可以看附件视频和附件图片，需要在黑色背景下才能发现改问题存在。

[car.apng.zip](https://github.com/onevcat/APNGKit/files/541075/car.apng.zip)
[video.zip](https://github.com/onevcat/APNGKit/files/541073/video.zip)
