### PR TITLE
Fix bug animate fast when start again after stop

### DIFF
--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -232,6 +232,7 @@ open class APNGImageView: APNGView {
         repeated = 0
         lastTimestamp = 0
         currentPassedDuration = 0
+        currentFrameDuration = 0
         currentFrameIndex = 0
         
         timer = nil


### PR DESCRIPTION
For catching up a frame index value it animates too fast.