### PR TITLE
Fixed deallocate warning

### DIFF
--- a/APNGKit/Frame.swift
+++ b/APNGKit/Frame.swift
@@ -100,7 +100,7 @@ class Frame {
     func clean() {
         cleaned = true
         bytes.deinitialize(count: length)
-        bytes.deallocate(capacity: length)
+        bytes.deallocate()
     }
     
     func updateCGImageRef(_ width: Int, height: Int, bits: Int, scale: CGFloat, blend: Bool) {

--- a/APNGKit/Frame.swift
+++ b/APNGKit/Frame.swift
@@ -100,7 +100,12 @@ class Frame {
     func clean() {
         cleaned = true
         bytes.deinitialize(count: length)
+        
+        #if swift(>=4.1)
         bytes.deallocate()
+        #else
+        bytes.deallocate(capacity: length)
+        #endif
     }
     
     func updateCGImageRef(_ width: Int, height: Int, bits: Int, scale: CGFloat, blend: Bool) {


### PR DESCRIPTION
'deallocate(capacity:)' is deprecated: Swift currently only supports freeing entire heap blocks, use deallocate() instead