### PR TITLE
[BUG] Fix faster animation when app send to background and gains focus again

### DIFF
--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -157,7 +157,9 @@ open class APNGImageView: APNGView {
             // fix issue that `APNGImageView` may cause crash when deinit
             layer?.contents = nil
             wantsLayer = false
-        #else
+        #endif 
+        
+        #if os(iOS)
             NotificationCenter.default.removeObserver(self, name:  Notification.Name.UIApplicationWillResignActive, object: nil)
             NotificationCenter.default.removeObserver(self, name:  Notification.Name.UIApplicationDidBecomeActive, object: nil)
         #endif
@@ -263,7 +265,7 @@ open class APNGImageView: APNGView {
      Add observers to the notification center to control app status
      */
     fileprivate func addObservers() {
-        #if !os(OSX)
+        #if os(iOS)
             NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: Notification.Name.UIApplicationWillResignActive, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: Notification.Name.UIApplicationDidBecomeActive, object: nil)
         #endif

--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -157,6 +157,9 @@ open class APNGImageView: APNGView {
             // fix issue that `APNGImageView` may cause crash when deinit
             layer?.contents = nil
             wantsLayer = false
+        #else
+            NotificationCenter.default.removeObserver(self, name:  Notification.Name.UIApplicationWillResignActive, object: nil)
+            NotificationCenter.default.removeObserver(self, name:  Notification.Name.UIApplicationDidBecomeActive, object: nil)
         #endif
     }
 
@@ -173,6 +176,8 @@ open class APNGImageView: APNGView {
         isAnimating = false
         autoStartAnimation = false
         super.init(coder: aDecoder)
+        
+        addObservers()
     }
     
     /**
@@ -186,6 +191,8 @@ open class APNGImageView: APNGView {
         isAnimating = false
         autoStartAnimation = false
         super.init(frame: frame)
+        
+        addObservers()
     }
     
     /**
@@ -236,6 +243,30 @@ open class APNGImageView: APNGView {
         currentFrameIndex = 0
         
         timer = nil
+    }
+    
+    /**
+     Stop animation when app send to background.
+     */
+    @objc private func appWillResignActive() {
+        stopAnimating()
+    }
+    
+    /**
+     Start animation when app become active.
+     */
+    @objc func appDidBecomeActive() {
+        startAnimating()
+    }
+    
+    /**
+     Add observers to the notification center to control app status
+     */
+    fileprivate func addObservers() {
+        #if !os(OSX)
+            NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: Notification.Name.UIApplicationWillResignActive, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: Notification.Name.UIApplicationDidBecomeActive, object: nil)
+        #endif
     }
     
     func tick() {


### PR DESCRIPTION
Added observers to notification center to control app status to stop/start animation when send to back/gains focus.