### PR TITLE
Adds ResignActive observers to initWithImage

### DIFF
--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -148,6 +148,8 @@ open class APNGImageView: APNGView {
         if let frame = image?.next(currentIndex: 0) {
             updateContents(frame.image)
         }
+        
+        addObservers()
     }
     
     deinit {


### PR DESCRIPTION
If you create APNGImageView in code with init(image: APNGImage?) it doesn't add the `UIApplicationWillResignActive`/`UIApplicationDidBecomeActive` observers