### PR TITLE
step any frames in one tick

### DIFF
--- a/APNGKit/APNGImageView.swift
+++ b/APNGKit/APNGImageView.swift
@@ -298,8 +298,11 @@ open class APNGImageView: APNGView {
         lastTimestamp = timestamp
         
         currentPassedDuration += elapsedTime
+        if let duration = image.duration, currentPassedDuration > duration {
+            currentPassedDuration = currentPassedDuration.truncatingRemainder(dividingBy: duration)
+        }
         
-        if currentPassedDuration >= currentFrameDuration {
+        while currentPassedDuration >= currentFrameDuration {
             currentFrameIndex = currentFrameIndex + 1
             
             if currentFrameIndex == image.frameCount {


### PR DESCRIPTION
#84

if the `elapsedTime` got too large, the animation steps fast because the frame can only step once in one tick.