### PR TITLE
Support compiling without Xcode

### DIFF
--- a/APNGKit/Disassembler.swift
+++ b/APNGKit/Disassembler.swift
@@ -30,6 +30,10 @@
     import UIKit
 #endif
 
+#if canImport(Clibpng)
+    import Clibpng
+#endif
+
 let signatureOfPNGLength = 8
 let kMaxPNGSize: UInt32 = 1000000;
 


### PR DESCRIPTION
This adds support for linking APNGKit with libpng compiled outside of Xcode. The module name follows Swift module name conventions for wrapping C libraries.