### PR TITLE
Prevent process abortion in libapng

### DIFF
--- a/APNGKit/Exports.swift
+++ b/APNGKit/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import APNGKitLibPNGErrorHandling

--- a/APNGKit/LibPNGErrorHandling/ErrorHandling.m
+++ b/APNGKit/LibPNGErrorHandling/ErrorHandling.m
@@ -1,0 +1,15 @@
+@import Darwin;
+@import Foundation;
+
+#import "ErrorHandling.h"
+
+BOOL try_png_read_frame_head(int *jmp_buf, png_structp png_ptr, png_infop info_ptr) {
+    if (!setjmp(jmp_buf)) {
+        png_read_frame_head(png_ptr, info_ptr);
+        return YES;
+    }
+    else {
+        // the structs will be cleaned in Disassembler
+        return NO;
+    }
+}

--- a/APNGKit/LibPNGErrorHandling/include/ErrorHandling.h
+++ b/APNGKit/LibPNGErrorHandling/include/ErrorHandling.h
@@ -1,0 +1,9 @@
+#ifndef ErrorHandling_h
+#define ErrorHandling_h
+
+@import Foundation;
+@import Clibpng;
+
+extern BOOL try_png_read_frame_head(int *jmp_buf, png_structp png_ptr, png_infop info_ptr);
+
+#endif /* ErrorHandling_h */

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,24 @@ let package = Package(
             name: "APNGKit",
             dependencies: [
                 "Clibpng",
+                "APNGKitLibPNGErrorHandling",
             ],
             path: "APNGKit",
-            exclude: ["libpng-apng"]
+            exclude: ["libpng-apng", "LibPNGErrorHandling"]
         ),
         .target(
             name: "Clibpng",
             path: "APNGKit/libpng-apng"),
+        .target(
+            name: "APNGKitLibPNGErrorHandling",
+            dependencies: [
+                "Clibpng",
+            ],
+            path: "APNGKit/LibPNGErrorHandling",
+            cSettings: [
+              .headerSearchPath("Internal"),
+           ]
+        )
     ],
     swiftLanguageVersions: [.v4_2]
 )


### PR DESCRIPTION
This is a discussion about an issue I had in APNGKit. I think it would be easier to have a discussion based on the PR.

# setjmp, longjmp

It seems this code is trying to save the program from a `longjmp` inside libapng:
https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/Disassembler.swift#L247

However, I don't think it works because `png_jmpbuf(pngPointer)` just returns the `jmpbuf`. A `setjmp` function call should be used, but it is no longer available in Swift for safety.

# The Actual Issue

I'm having a crash in my app. I created a demo: https://github.com/axl411/APNGKitCrash

The crash happens at this line: https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/Disassembler.swift#L168

Inside libapng, the error happens at: https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/libpng-apng/pngread.c#L333

A `longjmp` is called at last in libapng, but since no `setjmp` is called earlier, the program crashes.