### PR TITLE
Prevent crash in libapng

### DIFF
--- a/APNGKit/LibPNGErrorHandling/ErrorHandling.m
+++ b/APNGKit/LibPNGErrorHandling/ErrorHandling.m
@@ -1,0 +1,15 @@
+@import Darwin;
+@import Foundation;
+
+#import "ErrorHandling.h"
+
+BOOL try_png_read_frame_head(int *jmp_buf, png_structp png_ptr, png_infop info_ptr) {
+    if (!setjmp(jmp_buf)) {
+        png_read_frame_head(png_ptr, info_ptr);
+        return YES;
+    }
+    else {
+        // the structs will be cleaned in Disassembler
+        return NO;
+    }
+}

--- a/APNGKit/LibPNGErrorHandling/include/ErrorHandling.h
+++ b/APNGKit/LibPNGErrorHandling/include/ErrorHandling.h
@@ -1,0 +1,9 @@
+#ifndef ErrorHandling_h
+#define ErrorHandling_h
+
+@import Foundation;
+@import Clibpng;
+
+extern BOOL try_png_read_frame_head(int *jmp_buf, png_structp png_ptr, png_infop info_ptr);
+
+#endif /* ErrorHandling_h */

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,21 @@ let package = Package(
             name: "APNGKit",
             dependencies: [
                 "Clibpng",
+                "APNGKitLibPNGErrorHandling",
             ],
             path: "APNGKit",
-            exclude: ["libpng-apng"]
+            exclude: ["libpng-apng", "LibPNGErrorHandling"]
         ),
         .target(
             name: "Clibpng",
             path: "APNGKit/libpng-apng"),
+        .target(
+            name: "APNGKitLibPNGErrorHandling",
+            dependencies: [
+                "Clibpng",
+            ],
+            path: "APNGKit/LibPNGErrorHandling"
+        )
     ],
     swiftLanguageVersions: [.v4_2]
 )


### PR DESCRIPTION
This is a discussion about an issue I had in APNGKit. I think it would be easier to have a discussion based on the PR.

# setjmp, longjmp

It seems this code is trying to save the program from a `longjmp` inside libapng:
https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/Disassembler.swift#L247

However, I don't think it works because `png_jmpbuf(pngPointer)` just returns the `jmpbuf`. A `setjmp` function call should be used, but it is no longer available in Swift for safety.

# The Actual Issue

I'm having a crash in my app. I created a demo: https://github.com/axl411/APNGKitCrash

The crash happens at this line: https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/Disassembler.swift#L168

Inside libapng, the error happens at: https://github.com/onevcat/APNGKit/blob/704d1b58cf9ccc284d0c150e76bbcf2b5745c575/APNGKit/libpng-apng/pngread.c#L333

A `longjmp` is called at last in libapng, but since no `setjmp` is called earlier, the program crashes.

## Fix

To fix this we need to call `setjmp` earlier on the stack to escape from the error. I tried but it seems in Swift this is not possible. So the fix is to move the processing code that could call `longjmp` inside libapng to the ObjC env, and let ObjC handles the call to `setjmp` and the code for exiting.

In my PR I just move the call to `png_read_frame_head` to ObjC, and handle the `setjmp` call there.

However, `png_read_frame_head` is not the only function that could call `longjmp`, we should guard all calls to libapng with `setjmp`, in every method. So eventually, it seems the whole parsing code should be written in ObjC, guarded by `setjmp`, and only the interface code can be in Swift. Here's an example: https://github.com/line/apng-drawable/blob/7097a85fe94c18623fd7df6d833719289e4a105b/apng-drawable/src/main/cpp/apng-drawbale/ApngDecoder.cpp (pls search "setjmp")