### PR TITLE
Fix canvas creation for true color image

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Delegate",
+        "repositoryURL": "https://github.com/onevcat/Delegate.git",
+        "state": {
+          "branch": null,
+          "revision": "45c5ec58d5a9656a9cc729506e0ed3093ca8f772",
+          "version": "1.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Source/APNGKit/APNGImageRenderer.swift
+++ b/Source/APNGKit/APNGImageRenderer.swift
@@ -491,8 +491,10 @@ extension IHDR {
     
     var bitmapInfo: CGBitmapInfo {
         switch colorType {
-        case .greyscale, .trueColor:
+        case .greyscale:
             return CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue)
+        case .trueColor:
+            return CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
         case .greyscaleWithAlpha, .trueColorWithAlpha, .indexedColor:
             return CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
         }

--- a/Source/APNGKit/Chunk.swift
+++ b/Source/APNGKit/Chunk.swift
@@ -81,7 +81,7 @@ struct IHDR: Chunk {
         var componentsPerPixel: Int {
             switch self {
             case .greyscale: return 1
-            case .trueColor: return 3
+            case .trueColor: return 4
             case .indexedColor: return 1
             case .greyscaleWithAlpha: return 2
             case .trueColorWithAlpha: return 4


### PR DESCRIPTION
Now an image with `true color` without alpha can be loaded too.