### PR TITLE
Adding log level

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/APNGKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/APNGKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -573,7 +573,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1310;
-				LastUpgradeCheck = 1310;
+				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					4B5ECBC8272E29B9003930D4 = {
 						CreatedOnToolsVersion = 13.1;

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo-macOS.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/APNGKit/APNGImageView.swift
+++ b/Source/APNGKit/APNGImageView.swift
@@ -348,7 +348,7 @@ open class APNGImageView: PlatformView {
         guard let renderer = renderer, let _ = renderer.output /* the frame image is rendered */ else {
             // but unfortunately the decoding missed the target.
             // we can just wait for the next `step`.
-            printLog("Missed frame for image \(image): target index: \(nextFrameIndex), while displaying the current frame index: \(displayingFrameIndex).")
+            printLog("Missed frame for image \(image): target index: \(nextFrameIndex), while displaying the current frame index: \(displayingFrameIndex).", logLevel: .verbose)
             onFrameMissed(nextFrameIndex)
             frameMissed = true
             return

--- a/Source/APNGKit/APNGImageView.swift
+++ b/Source/APNGKit/APNGImageView.swift
@@ -348,7 +348,7 @@ open class APNGImageView: PlatformView {
         guard let renderer = renderer, let _ = renderer.output /* the frame image is rendered */ else {
             // but unfortunately the decoding missed the target.
             // we can just wait for the next `step`.
-            printLog("Missed frame for image \(image): target index: \(nextFrameIndex), while displaying the current frame index: \(displayingFrameIndex).", logLevel: .verbose)
+            printLog("Missed frame for image \(image): target index: \(nextFrameIndex), while displaying the current frame index: \(displayingFrameIndex).", logLevel: .info)
             onFrameMissed(nextFrameIndex)
             frameMissed = true
             return

--- a/Source/APNGKit/Extensions.swift
+++ b/Source/APNGKit/Extensions.swift
@@ -63,6 +63,11 @@ extension UnsignedInteger {
     }
 }
 
-func printLog(_ item: Any) {
-    print("[APNGKit] \(item)")
+func printLog(_ item: Any, logLevel: LogLevel = .default) {
+    if logLevel == .off || LogLevel.current == .off {
+        return
+    }
+    if logLevel <= LogLevel.current {
+        print("[APNGKit] \(item)")
+    }
 }

--- a/Source/APNGKit/LogLevel.swift
+++ b/Source/APNGKit/LogLevel.swift
@@ -1,0 +1,27 @@
+//
+//  LogLevel.swift
+//  
+// 
+//  Created by: onevcat (Wei Wang) on 2022/05/29
+//
+
+import Foundation
+
+/// Log level when APNGKit to determine if the log should be printed into console.
+public enum LogLevel: Int32, Comparable {
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+    
+    /// The log should be turned off.
+    case off       = 0
+    /// The default log level. Only critical issues or errors will be printed
+    case `default` = 0x00000001
+    /// Also log some ignorable logs for diagnose purpose.
+    case info      = 0x00001000
+    /// Verbose log can be used to show all information. Not in use now.
+    case verbose   = 0x10000000
+    
+    /// The global setting of the log printed by APNGKit.
+    public static var current: LogLevel = .default
+}


### PR DESCRIPTION
For #128 

When an image frame missing happens (usually due to a big image decoding and very short duration per frame), it trends to missing not only one frame but all the following frames. When this happens, the console log could be quite noisy. Most cases, the frame missing is acceptable.

This PR adds a `LogLevel` and `LogLevel.current` to control if a verbose print should happen.