### PR TITLE
Add notSkipAlphaChannel options.

### DIFF
--- a/Source/APNGKit/APNGImageRenderer.swift
+++ b/Source/APNGKit/APNGImageRenderer.swift
@@ -24,11 +24,19 @@ class APNGImageRenderer {
     private var foundMultipleAnimationControl: Bool = false
     private var expectedSequenceNumber: Int = 0
     
-    init(decoder: APNGDecoder) throws {
+    init(decoder: APNGDecoder, shouldRenderWithAlpha: Bool = false) throws {
         self.decoder = decoder
         self.reader = try decoder.reader.clone()
         
         let imageHeader = decoder.imageHeader
+        
+        let bitmapInfo: CGBitmapInfo
+        if shouldRenderWithAlpha {
+            bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        } else {
+            bitmapInfo = imageHeader.bitmapInfo
+        }
+        
         guard let outputBuffer = CGContext(
             data: nil,
             width: imageHeader.width,
@@ -36,7 +44,7 @@ class APNGImageRenderer {
             bitsPerComponent: imageHeader.bitDepthPerComponent,
             bytesPerRow: imageHeader.bytesPerRow,
             space: imageHeader.colorSpace,
-            bitmapInfo: imageHeader.bitmapInfo.rawValue
+            bitmapInfo: bitmapInfo.rawValue
         ) else {
             throw APNGKitError.decoderError(.canvasCreatingFailed)
         }

--- a/Source/APNGKit/APNGImageView.swift
+++ b/Source/APNGKit/APNGImageView.swift
@@ -25,6 +25,9 @@ open class APNGImageView: PlatformView {
     /// of `self`. Default is `true`.
     open var autoStartAnimationWhenSetImage = true
     
+    /// Enable this option to always reference the alpha channel during rendering. Default is `false`.
+    open var shouldRenderWithAlpha = false
+    
     /// A delegate called every time when a "play" (a single loop of the animated image) is done. The parameter number
     /// is the count of played loops.
     ///
@@ -95,9 +98,10 @@ open class APNGImageView: PlatformView {
     
     /// Creates an APNG image view with the specified animated image.
     /// - Parameter image: The initial image to display in the image view.
-    public convenience init(image: APNGImage?, autoStartAnimating: Bool = true) {
+    public convenience init(image: APNGImage?, autoStartAnimating: Bool = true, shouldRenderWithAlpha: Bool = false) {
         self.init(frame: .zero)
         self.autoStartAnimationWhenSetImage = autoStartAnimating
+        self.shouldRenderWithAlpha = shouldRenderWithAlpha
         self.image = image
     }
     
@@ -212,7 +216,7 @@ open class APNGImageView: PlatformView {
             unsetImage()
             
             do {
-                renderer = try APNGImageRenderer(decoder: nextImage.decoder)
+                renderer = try APNGImageRenderer(decoder: nextImage.decoder, shouldRenderWithAlpha: shouldRenderWithAlpha)
             } catch {
                 printLog("Error happens while creating renderer for image. \(error)")
                 defaultDecodingErrored(


### PR DESCRIPTION
It looks the WebKit always lookup alpha channel regardless of color type.

This APNG image has a color type that is true color(2).
But, Safari renders it with alpha channel.
![7e3f65324c9de7f6](https://github.com/onevcat/APNGKit/assets/2066707/e550d002-11f4-407d-b239-9d0cc588c7a8)

So, I added `notSkipAlphaChannel` to `DecodingOptions`.
This option always uses alpha channel when color type is true color.

I would like you to review my architecture, variable names and proposal.

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2023-10-02 at 23 01 34](https://github.com/onevcat/APNGKit/assets/2066707/bedf4685-b536-4152-b6b6-a640ccf312e1)|![Simulator Screenshot - iPhone 15 - 2023-10-02 at 23 02 37](https://github.com/onevcat/APNGKit/assets/2066707/3be1249d-a9ea-4f5b-a02c-f62d95b7a9f5)|

