### PR TITLE
visionOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "APNGKit",
-    platforms: [.macOS(.v10_11), .iOS(.v9), .tvOS(.v9)],
+    platforms: [.macOS(.v10_11), .iOS(.v13), .tvOS(.v9)],
     products: [
         .library(name: "APNGKit", targets: ["APNGKit"])
     ],

--- a/Source/APNGKit/CrossPlatform.swift
+++ b/Source/APNGKit/CrossPlatform.swift
@@ -12,7 +12,7 @@ import UIKit
 public typealias PlatformDrivingTimer = DisplayTimer
 public typealias PlatformView = UIView
 public typealias PlatformImage = UIImage
-var screenScale: CGFloat { UIScreen.main.scale }
+var screenScale: CGFloat { UITraitCollection.current.displayScale }
 
 extension Notification.Name {
     static var applicationDidBecomeActive = UIApplication.didBecomeActiveNotification

--- a/Tests/APNGKitTests/APNGImageViewTests.swift
+++ b/Tests/APNGKitTests/APNGImageViewTests.swift
@@ -23,8 +23,11 @@ class ViewControllerStub {
     func setupViewController(_ input: UIViewController) -> UIViewController {
 
         input.loadViewIfNeeded()
-        
+        #if os(visionOS)
+        window = UIWindow(frame: .init(x: 0, y: 0, width: 640, height: 480))
+        #else
         window = UIWindow(frame: UIScreen.main.bounds)
+        #endif
         window.rootViewController = input
         window.makeKeyAndVisible()
         return input


### PR DESCRIPTION
This adds support for visionOS by using UITraitCollection.current to get the correct display scale. Downside: bumps minimum iOS requirements from 9 to 13.